### PR TITLE
Add form support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repo contains the source code for everything `HtmlWidget`-related.
 | [fwfh_svg](./packages/fwfh_svg/)                                   | [![pub package](https://img.shields.io/pub/v/fwfh_svg.svg)](https://pub.dev/packages/fwfh_svg)                                           |
 | [fwfh_url_launcher](./packages/fwfh_url_launcher/)                 | [![pub package](https://img.shields.io/pub/v/fwfh_url_launcher.svg)](https://pub.dev/packages/fwfh_url_launcher)                         |
 | [fwfh_webview](./packages/fwfh_webview/)                           | [![pub package](https://img.shields.io/pub/v/fwfh_webview.svg)](https://pub.dev/packages/fwfh_webview)                                   |
+| [fwfh_form](./packages/fwfh_form/)                             | [![pub package](https://img.shields.io/pub/v/fwfh_form.svg)](https://pub.dev/packages/fwfh_form)                                   |
 | [Demo app](./demo_app/)                                            | https://demo.fwfh.dev, [supported/tags.html](https://demo.fwfh.dev/supported/tags.html)                                                  |
 | Special [dartpad](https://dartpad.dev) with our packages           | https://try.fwfh.dev                                                                                                                     |
 

--- a/packages/fwfh_form/CHANGELOG.md
+++ b/packages/fwfh_form/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.16.0
+
+- Initial release with basic support for FORM, INPUT and TEXTAREA tags.

--- a/packages/fwfh_form/LICENSE
+++ b/packages/fwfh_form/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Dao Hoang Son
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/fwfh_form/README.md
+++ b/packages/fwfh_form/README.md
@@ -1,0 +1,37 @@
+# FormFactory
+
+[![Flutter](https://github.com/daohoangson/flutter_widget_from_html/actions/workflows/flutter.yml/badge.svg)](https://github.com/daohoangson/flutter_widget_from_html/actions/workflows/flutter.yml)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=daohoangson_flutter_widget_from_html&metric=coverage)](https://sonarcloud.io/summary/new_code?id=daohoangson_flutter_widget_from_html)
+
+WidgetFactory extension to render basic HTML forms.
+This is a companion add-on for [flutter_widget_from_html_core](https://pub.dev/packages/flutter_widget_from_html_core) package.
+
+## Getting Started
+
+Add this to your app's `pubspec.yaml` file:
+
+```yaml
+dependencies:
+  flutter_widget_from_html_core: any
+  fwfh_form: ^0.16.0
+```
+
+## Usage
+
+Then use `HtmlWidget` with a custom factory:
+
+```dart
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:fwfh_form/fwfh_form.dart';
+
+// ...
+
+HtmlWidget(
+  html,
+  factoryBuilder: () => MyWidgetFactory(),
+)
+
+// ...
+
+class MyWidgetFactory extends WidgetFactory with FormFactory {}
+```

--- a/packages/fwfh_form/analysis_options.yaml
+++ b/packages/fwfh_form/analysis_options.yaml
@@ -1,0 +1,14 @@
+include: package:lint/analysis_options_package.yaml
+
+analyzer:
+  errors:
+    todo: info
+
+linter:
+  rules:
+    always_put_control_body_on_new_line: true
+
+    # relative vs. package imports
+    always_use_package_imports: false
+    avoid_relative_lib_imports: true
+    prefer_relative_imports: true

--- a/packages/fwfh_form/example/main.dart
+++ b/packages/fwfh_form/example/main.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:fwfh_form/fwfh_form.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'fwfh_form',
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('FormFactory Demo'),
+        ),
+        body: Center(
+          child: HtmlWidget(
+            '<form><input placeholder="Your name"><button type="submit">Submit</button></form>',
+            factoryBuilder: () => MyWidgetFactory(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class MyWidgetFactory extends WidgetFactory with FormFactory {}

--- a/packages/fwfh_form/lib/fwfh_form.dart
+++ b/packages/fwfh_form/lib/fwfh_form.dart
@@ -1,0 +1,1 @@
+export 'src/form_factory.dart';

--- a/packages/fwfh_form/lib/src/form_factory.dart
+++ b/packages/fwfh_form/lib/src/form_factory.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+
+import 'internal/tag_form.dart';
+
+/// A mixin that can render simple HTML forms.
+mixin FormFactory on WidgetFactory {
+  BuildOp? _tagForm;
+  BuildOp? _tagInput;
+  BuildOp? _tagTextArea;
+
+  @override
+  void parse(BuildTree tree) {
+    switch (tree.element.localName) {
+      case kTagForm:
+        tree.register(_tagForm ??= TagForm(this).buildOp);
+      case kTagInput:
+        tree.register(_tagInput ??= TagInput().buildOp);
+      case kTagTextArea:
+        tree.register(_tagTextArea ??= TagTextArea().buildOp);
+    }
+    super.parse(tree);
+  }
+}

--- a/packages/fwfh_form/lib/src/internal/tag_form.dart
+++ b/packages/fwfh_form/lib/src/internal/tag_form.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+
+const kTagForm = 'form';
+const kTagInput = 'input';
+const kTagTextArea = 'textarea';
+const kAttributeInputType = 'type';
+const kAttributeInputValue = 'value';
+const kAttributeInputPlaceholder = 'placeholder';
+
+class TagForm {
+  final FormFactory wf;
+
+  TagForm(this.wf);
+
+  BuildOp get buildOp => BuildOp(
+        debugLabel: kTagForm,
+        alwaysRenderBlock: true,
+        onRenderedChildren: (tree, children) {
+          final column = wf.buildColumnPlaceholder(tree, children);
+          if (column == null) {
+            return null;
+          }
+          return column..wrapWith((context, child) => Form(child: child));
+        },
+      );
+}
+
+class TagInput {
+  BuildOp get buildOp => BuildOp(
+        debugLabel: kTagInput,
+        onRenderBlock: (tree, placeholder) {
+          final attrs = tree.element.attributes;
+          final type = attrs[kAttributeInputType] ?? 'text';
+          switch (type) {
+            case 'text':
+              return WidgetPlaceholder(
+                debugLabel: kTagInput,
+                child: TextFormField(
+                  decoration: InputDecoration(
+                    hintText: attrs[kAttributeInputPlaceholder],
+                  ),
+                  initialValue: attrs[kAttributeInputValue],
+                ),
+              );
+            case 'submit':
+              final label = attrs[kAttributeInputValue] ?? 'Submit';
+              return WidgetPlaceholder(
+                debugLabel: kTagInput,
+                child: ElevatedButton(
+                  onPressed: () {},
+                  child: Text(label),
+                ),
+              );
+            default:
+              return placeholder;
+          }
+        },
+      );
+}
+
+class TagTextArea {
+  BuildOp get buildOp => BuildOp(
+        debugLabel: kTagTextArea,
+        onRenderBlock: (tree, placeholder) {
+          final attrs = tree.element.attributes;
+          return WidgetPlaceholder(
+            debugLabel: kTagTextArea,
+            child: TextFormField(
+              decoration: InputDecoration(
+                hintText: attrs[kAttributeInputPlaceholder],
+              ),
+              initialValue: tree.element.text,
+              maxLines: null,
+            ),
+          );
+        },
+      );
+}

--- a/packages/fwfh_form/pubspec.yaml
+++ b/packages/fwfh_form/pubspec.yaml
@@ -1,0 +1,29 @@
+name: fwfh_form
+version: 0.16.0
+description: WidgetFactory extension to render simple FORM elements.
+homepage: https://github.com/daohoangson/flutter_widget_from_html
+
+environment:
+  flutter: ">=3.10.0"
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_widget_from_html_core: ">=0.8.0 <0.17.0"
+
+dependency_overrides:
+  flutter_widget_from_html_core:
+    path: ../core
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  lint: any
+
+funding:
+  - https://patreon.com/daohoangson
+  - https://buymeacoffee.com/daohoangson
+
+topics:
+  - fwfh

--- a/packages/fwfh_form/test/_.dart
+++ b/packages/fwfh_form/test/_.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:fwfh_form/fwfh_form.dart';
+
+import '../../core/test/_.dart' as helper;
+
+String? formExplainer(helper.Explainer parent, Widget widget) {
+  if (widget is Form) return '[Form]';
+  if (widget is TextFormField) return '[TextFormField]';
+  if (widget is ElevatedButton) return '[ElevatedButton]';
+  return null;
+}
+
+Future<String> explain(WidgetTester tester, String html) => helper.explain(
+      tester,
+      null,
+      explainer: formExplainer,
+      hw: HtmlWidget(
+        html,
+        key: helper.hwKey,
+        factoryBuilder: () => _WidgetFactory(),
+      ),
+    );
+
+class _WidgetFactory extends WidgetFactory with FormFactory {}

--- a/packages/fwfh_form/test/form_factory_test.dart
+++ b/packages/fwfh_form/test/form_factory_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '_.dart';
+
+void main() {
+  testWidgets('renders basic form', (tester) async {
+    const html = '<form>'
+        '<input placeholder="foo">'
+        '<textarea>bar</textarea>'
+        '<input type="submit" value="Send">'
+        '</form>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals('[Form,[TextFormField],[TextFormField],[ElevatedButton]]'),
+    );
+  });
+}

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -53,6 +53,14 @@ if [ -z ${UPDATE_GOLDENS+x} ]; then
       echo 'packages/fwfh_webview OK'
   )
 
+  (
+    cd ./packages/fwfh_form &&
+      flutter analyze &&
+      flutter test "$@" &&
+      echo 'packages/fwfh_form OK'
+  
+  )
+
   if [ ! -z ${CHROMEDRIVER_PORT_4444+x} ]; then
     (
       cd ./packages/fwfh_webview &&


### PR DESCRIPTION
## Summary
- add new `fwfh_form` package for rendering HTML forms
- document new package and usage
- run forms tests via test script

## Testing
- `bash tool/test.sh` *(fails: `flutter: command not found`)*